### PR TITLE
Check for presence of facet config.

### DIFF
--- a/europeana-blacklight.gemspec
+++ b/europeana-blacklight.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'activesupport', '>= 4.0', '< 5.0'
-  spec.add_dependency 'blacklight', '>= 5.12.0', '< 6.0.0'
+  spec.add_dependency 'blacklight', '>= 5.12.0', '< 5.16.0'
   spec.add_dependency 'europeana-api', '~> 0.4.1'
   spec.add_dependency 'iso-639', '~> 0.2.5'
   spec.add_dependency 'kaminari', '~> 0.16'

--- a/lib/europeana/blacklight/search_builder.rb
+++ b/lib/europeana/blacklight/search_builder.rb
@@ -115,7 +115,7 @@ module Europeana
 
         salient_facets = blacklight_params[:f].select do |k, _v|
           facet = blacklight_config.facet_fields[k]
-          facet.query && (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request))
+          facet.present? && facet.query && (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request))
         end
 
         salient_facets.each_pair do |facet_field, value_list|

--- a/spec/europeana/blacklight/document_spec.rb
+++ b/spec/europeana/blacklight/document_spec.rb
@@ -174,11 +174,21 @@ RSpec.describe Europeana::Blacklight::Document do
             expect(subject.fetch('proxies.dcType')).to eq(['Picture'])
           end
         end
+        context 'with key for default locale' do
+          before do
+            I18n.locale = :fr
+            I18n.default_locale = :en
+          end
+          it 'returns default locale value' do
+            expect(subject.fetch('proxies.dcType')).to eq(['Picture'])
+          end
+        end
         context 'with key "def"' do
           before do
             I18n.locale = :fr
+            I18n.default_locale = :es
           end
-          it 'returns def value' do
+          it 'returns default locale value' do
             expect(subject.fetch('proxies.dcType')).to eq(['Image'])
           end
         end


### PR DESCRIPTION
To prevent errors when a facet is present in query params that is not registered in the Blacklight config.
