### PR TITLE
Max 10 terms per MLT field

### DIFF
--- a/lib/europeana/blacklight/document/more_like_this.rb
+++ b/lib/europeana/blacklight/document/more_like_this.rb
@@ -26,7 +26,7 @@ module Europeana
 
         def more_like_this_field_terms(*fields)
           fields.flatten.map do |field|
-            fetch(field, []).compact
+            fetch(field, []).compact[0..9]
           end.flatten
         end
 


### PR DESCRIPTION
To prevent very long API search URLs resulting in HTTP errors.
