### PR TITLE
Do not restrict faceted fields

### DIFF
--- a/lib/europeana/blacklight/search_builder.rb
+++ b/lib/europeana/blacklight/search_builder.rb
@@ -205,8 +205,7 @@ module Europeana
       def api_request_facet_fields
         @api_request_facet_fields ||= blacklight_config.facet_fields.select do |field_name, facet|
           !facet.query &&
-          (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request)) &&
-          (field_name == 'REUSABILITY' || Europeana::API::Search::Fields.include?(field_name))
+          (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request))
         end
       end
 

--- a/lib/europeana/blacklight/search_builder.rb
+++ b/lib/europeana/blacklight/search_builder.rb
@@ -205,7 +205,7 @@ module Europeana
       def api_request_facet_fields
         @api_request_facet_fields ||= blacklight_config.facet_fields.select do |field_name, facet|
           !facet.query &&
-          (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request))
+            (facet.include_in_request || (facet.include_in_request.nil? && blacklight_config.add_facet_fields_to_solr_request))
         end
       end
 


### PR DESCRIPTION
To allow for language-aware fields like `cc_skos_prefLabel.en` to be faceted on, and in general any others that may be added in future.
