### PR TITLE
Handle empty range values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ rvm:
 notifications:
   email: false
 sudo: false
-bundler_args: --without development
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
   - 2.2.1
+  - 2.3.1
 notifications:
   email: false
 sudo: false
+bundler_args: --without development
+cache:
+  bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ group :test do
   gem 'coveralls', require: false
 end
 
-group :test, :develop do
+group :test, :development do
   gem 'rubocop', '0.39.0', require: false # only update when Hound does
 end

--- a/lib/europeana/blacklight/search_builder/ranges.rb
+++ b/lib/europeana/blacklight/search_builder/ranges.rb
@@ -13,8 +13,10 @@ module Europeana
         def add_range_qf_to_api(api_parameters)
           return unless blacklight_params.key?(:range) && blacklight_params[:range].is_a?(Hash)
           blacklight_params[:range].each_pair do |range_field, range_values|
+            range_begin = range_values[:begin].blank? ? '*' : range_values[:begin]
+            range_end = range_values[:end].blank? ? '*' : range_values[:end]
             api_parameters[:qf] ||= []
-            api_parameters[:qf] << "#{range_field}:[#{range_values[:begin]} TO #{range_values[:end]}]"
+            api_parameters[:qf] << "#{range_field}:[#{range_begin} TO #{range_end}]"
           end
         end
       end


### PR DESCRIPTION
By passing '*' to the API for Lucene open-ended range queries.
